### PR TITLE
Kill node child process / worker when main process stops

### DIFF
--- a/ssr/src/worker.rs
+++ b/ssr/src/worker.rs
@@ -60,6 +60,8 @@ impl Process {
     ) -> Result<Child, io::Error> {
         let mut cmd = Command::new(Process::SHELL);
 
+        cmd.kill_on_drop(true);
+
         cmd.args(Process::cmd(&format!(
             "node {}",
             js_worker.as_path().display()


### PR DESCRIPTION
Hi,

I noticed that the node worker process keeps running in the background after I killed the main process.

Seems to be fixed when using `tokio`'s [`kill_on_drop`](https://docs.rs/tokio/0.2.0/tokio/process/struct.Command.html#method.kill_on_drop) for the child process. 

Tested successfully with MacOS and Debian.