### PR TITLE
Changes .data by .app_data in actix example to prevent deprecation msg

### DIFF
--- a/examples/actix-web-hello-world/src/main.rs
+++ b/examples/actix-web-hello-world/src/main.rs
@@ -23,7 +23,7 @@ pub async fn main() -> std::io::Result<()> {
 
     HttpServer::new(move || {
         App::new()
-            .data(ssr.clone())
+            .app_data(Data::new(ssr.clone()))
             .route("/", web::get().to(hello_world))
     })
     .bind("127.0.0.1:3000")?


### PR DESCRIPTION
The example was previously currently working, but if you search today for actix-web on the web, the first link will send you to the actix-web v4.4.1. The `.data()` documentation says the method is deprecated: https://docs.rs/actix-web/4.4.1/actix_web/struct.App.html#method.data

First time I tried to run the actix example, I didn't know how to test the example and see the `Hello, world!` message on my browser. I've got really confused by reading the link above because it didn't match the function I was reading on the source code. With the code changes on this PR, I think it will be easier for a new comer to understand what the example does if the example contains the `.app_data` function instead of the `.data()` function.

v3.2.0 source code

data: https://github.com/actix/actix-web/blob/42f51eb962af48b85b944fe64d24f4a81ad4650e/src/app.rs#L103
app_data: https://github.com/actix/actix-web/blob/42f51eb962af48b85b944fe64d24f4a81ad4650e/src/app.rs#L146

v4.4.0 source deo

data: https://github.com/actix/actix-web/blob/e50bceb91493087d4059e605d94c13a11b09e747/actix-web/src/app.rs#L124
app_data: https://github.com/actix/actix-web/blob/e50bceb91493087d4059e605d94c13a11b09e747/actix-web/src/app.rs#L115

NOTE: If you just attempt to update the application to version 4.4.0 or 4.0.0 you will get a panick error telling you there is
no reactor running. But I guess that's a different problem

![no_reactor_running_error](https://github.com/shakacode/ssr-rs/assets/3003032/15cd69eb-19e3-41a6-9330-43eec02bb161)

Link to v3.3.0 documentation

thread 'main' panicked at 'there is no reactor running, must be called from the context of Tokio runtime', /home/karl/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-0.2.24/src/io/driver/mod.rs:204:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[JS] Worker [id: 25506 port: 9000]: Node.js version: v18.16.1
[JS] Worker [id: 25506 port: 9000]: Uncaught Exception: Error: listen EADDRINUSE: address already in use :::9000
